### PR TITLE
feat: update sorting logic in the get orders endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The migration commands can be found on the `Makefile`.
 The Swagger is available on the path `/swagger/index.html`.
 
 Whenever new annotations are added in the codebase please run the command below and commit the changes to this repository.
-Ensure you have the Swage CLI installed.
+Ensure you have the Swag CLI installed.
 
 ```
 swag init -g ./cmd/main.go -o cmd/docs

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The migration commands can be found on the `Makefile`.
 The Swagger is available on the path `/swagger/index.html`.
 
 Whenever new annotations are added in the codebase please run the command below and commit the changes to this repository.
+Ensure you have the Swage CLI installed.
 
 ```
 swag init -g ./cmd/main.go -o cmd/docs

--- a/internal/core/usecases/orders/find_all.go
+++ b/internal/core/usecases/orders/find_all.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 
+	valueobjects "github.com/Pos-tech-FIAP-GO-HORSE/order-management/internal/core/domain/valueObjects"
 	"github.com/Pos-tech-FIAP-GO-HORSE/order-management/internal/core/ports/order/find_all_orders"
 	"github.com/Pos-tech-FIAP-GO-HORSE/order-management/internal/infra/repositories"
 	"github.com/Pos-tech-FIAP-GO-HORSE/order-management/internal/utils"
@@ -36,7 +37,7 @@ func (uc *FindAllOrdersUseCase) Execute(ctx context.Context, input find_all_orde
 
 	for _, order := range foundOrders {
 		// Only include orders with status 'Ready', 'Preparing', or 'Received'
-		if order.Status != "Ready" && order.Status != "Preparing" && order.Status != "Received" {
+		if order.Status != valueobjects.TypeReady && order.Status != valueobjects.TypePreparing && order.Status != valueobjects.TypeReceived {
 			continue
 		}
 
@@ -65,7 +66,11 @@ func (uc *FindAllOrdersUseCase) Execute(ctx context.Context, input find_all_orde
 
 	// Sort orders by status priority first, then by date (latest first)
 	sort.Slice(orders, func(i, j int) bool {
-		statusPriority := map[string]int{"Ready": 0, "Preparing": 1, "Received": 2}
+		statusPriority := map[string]int{
+			valueobjects.TypeReady:     0,
+			valueobjects.TypePreparing: 1,
+			valueobjects.TypeReceived:  2,
+		}
 
 		// First, sort by status priority
 		if statusPriority[orders[i].Status] != statusPriority[orders[j].Status] {

--- a/internal/core/usecases/orders/find_all.go
+++ b/internal/core/usecases/orders/find_all.go
@@ -2,6 +2,7 @@ package orders
 
 import (
 	"context"
+	"sort"
 
 	"github.com/Pos-tech-FIAP-GO-HORSE/order-management/internal/core/ports/order/find_all_orders"
 	"github.com/Pos-tech-FIAP-GO-HORSE/order-management/internal/infra/repositories"
@@ -31,9 +32,14 @@ func (uc *FindAllOrdersUseCase) Execute(ctx context.Context, input find_all_orde
 		return find_all_orders.Output{}, err
 	}
 
-	orders := make([]find_all_orders.Order, len(foundOrders))
+	orders := make([]find_all_orders.Order, 0, len(foundOrders))
 
-	for i, order := range foundOrders {
+	for _, order := range foundOrders {
+		// Only include orders with status 'Ready', 'Preparing', or 'Received'
+		if order.Status != "Ready" && order.Status != "Preparing" && order.Status != "Received" {
+			continue
+		}
+
 		items := make([]find_all_orders.Item, len(order.Items))
 
 		for i := range order.Items {
@@ -45,7 +51,7 @@ func (uc *FindAllOrdersUseCase) Execute(ctx context.Context, input find_all_orde
 			}
 		}
 
-		orders[i] = find_all_orders.Order{
+		orders = append(orders, find_all_orders.Order{
 			ID:                       order.ID,
 			UserID:                   order.UserID,
 			Items:                    items,
@@ -54,8 +60,21 @@ func (uc *FindAllOrdersUseCase) Execute(ctx context.Context, input find_all_orde
 			Status:                   string(order.Status),
 			CreatedAt:                order.CreatedAt,
 			UpdatedAt:                order.UpdatedAt,
-		}
+		})
 	}
+
+	// Sort orders by status priority first, then by date (latest first)
+	sort.Slice(orders, func(i, j int) bool {
+		statusPriority := map[string]int{"Ready": 0, "Preparing": 1, "Received": 2}
+
+		// First, sort by status priority
+		if statusPriority[orders[i].Status] != statusPriority[orders[j].Status] {
+			return statusPriority[orders[i].Status] < statusPriority[orders[j].Status]
+		}
+
+		// If status is the same, sort by date (latest first)
+		return orders[i].CreatedAt.After(orders[j].CreatedAt)
+	})
 
 	return find_all_orders.Output{
 		CurrentPage: page,


### PR DESCRIPTION
Only include orders with status 'Ready', 'Preparing', or 'Received' in the list. Then sort them out by status priority first, then by date (latest first).